### PR TITLE
Vert.x: CWE-295: Improper Certificate Validation

### DIFF
--- a/jsonmerge-core/pom.xml
+++ b/jsonmerge-core/pom.xml
@@ -79,6 +79,12 @@
             <artifactId>vertx-core</artifactId>
             <version>${vertx.version}</version>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Vulnerability

- [CWE-295](https://cwe.mitre.org/data/definitions/295.html): Improper Certificate Validation
- Vulnerable module: io.netty:netty-handler
- Introduced through: io.vertx:vertx-core@4.3.6

### Overview
[io.netty:netty-handler](https://github.com/netty/netty.git/netty-handler) is a library that provides an asynchronous event-driven network application framework and tools for rapid development of maintainable high performance and high scalability protocol servers and clients. In other words, Netty is a NIO client server framework which enables quick and easy development of network applications such as protocol servers and clients. It greatly simplifies and streamlines network programming such as TCP and UDP socket server.

Affected versions of this package are vulnerable to Improper Certificate Validation. Certificate hostname validation is disabled by default in Netty 4.1.x which makes it potentially susceptible to Man-in-the-Middle attacks.