### PR TITLE
Vert.x: CVE-2022-41915: HTTP Response Splitting

### DIFF
--- a/jsonmerge-core/pom.xml
+++ b/jsonmerge-core/pom.xml
@@ -84,6 +84,10 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-handler</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## Vulnerability

- [CVE-2022-41915](https://www.cve.org/CVERecord?id=CVE-2022-41915)
- Introduced through: io.vertx:vertx-core@4.3.6

### Overview

[io.netty:netty-codec](https://github.com/netty/netty) is an event-driven asynchronous network application framework.

Affected versions of this package are vulnerable to HTTP Response Splitting when calling DefaultHttpHeaders.set on an iterator of values, because header value validation is not performed.