### PR TITLE
Upgrade Vert.x Core to 4.5.4

### DIFF
--- a/jsonmerge-core/pom.xml
+++ b/jsonmerge-core/pom.xml
@@ -35,7 +35,7 @@
         <json-smart.version>2.5.0</json-smart.version>
         <json-org.version>20231013</json-org.version>
         <jackson.version>2.16.1</jackson.version>
-        <vertx.version>4.5.2</vertx.version>
+        <vertx.version>4.5.4</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Upgrade Vert.x from version 4.5.2 to 4.5.4 to solve a Resource Exhaustion vulnerability: 
https://security.snyk.io/vuln/SNYK-JAVA-IOVERTX-6231834